### PR TITLE
[Experimental] File upload confirmation dialog

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,9 +38,17 @@ import { LabelDefinitionPopupComponent } from './shared/label-definition-popup/l
 import { HeaderComponent } from './shared/layout';
 import { markedOptionsFactory } from './shared/lib/marked';
 import { SharedModule } from './shared/shared.module';
+import { UploadDialogComponent } from './shared/upload-dialog/upload-dialog.component';
 
 @NgModule({
-  declarations: [AppComponent, HeaderComponent, UserConfirmationComponent, LabelDefinitionPopupComponent, SessionFixConfirmationComponent],
+  declarations: [
+    AppComponent,
+    HeaderComponent,
+    UserConfirmationComponent,
+    LabelDefinitionPopupComponent,
+    SessionFixConfirmationComponent,
+    UploadDialogComponent
+  ],
   imports: [
     BrowserModule,
     PhaseTesterResponseModule,
@@ -95,7 +103,7 @@ import { SharedModule } from './shared/shared.module';
     }
   ],
   bootstrap: [AppComponent],
-  entryComponents: [UserConfirmationComponent, SessionFixConfirmationComponent, LabelDefinitionPopupComponent]
+  entryComponents: [UploadDialogComponent, UserConfirmationComponent, SessionFixConfirmationComponent, LabelDefinitionPopupComponent]
 })
 export class AppModule {
   constructor(private apollo: Apollo, private httpLink: HttpLink, private authService: AuthService) {

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -32,19 +32,16 @@ export class DialogService {
   }
 
   openUploadConfirmationDialog(file: File) {
-    const preview = new Observable<string | ArrayBuffer>((observer) => {
-      if (this.uploadService.isImageFile(file.name)) {
+    let preview = undefined;
+    if (this.uploadService.isImageFile(file.name)) {
+      preview = new Observable<string | ArrayBuffer>((observer) => {
         const reader = new FileReader();
         reader.onload = () => {
           observer.next(reader.result);
         };
         reader.readAsDataURL(file);
-      } else {
-        observer.next(
-          'https://media.istockphoto.com/photos/european-short-haired-cat-picture-id1072769156?k=20&m=1072769156&s=612x612&w=0&h=k6eFXtE7bpEmR2ns5p3qe_KYh098CVLMz4iKm5OuO6Y='
-        );
-      }
-    });
+      });
+    }
     return this.dialog.open(UploadDialogComponent, {
       data: {
         name: file.name,

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import { UploadDialogComponent } from '../../shared/upload-dialog/upload-dialog.component';
+import { Observable } from 'rxjs';
 import { LabelDefinitionPopupComponent } from '../../shared/label-definition-popup/label-definition-popup.component';
+import { UploadDialogComponent } from '../../shared/upload-dialog/upload-dialog.component';
 import { UserConfirmationComponent } from '../guards/user-confirmation/user-confirmation.component';
 import { UploadService } from './upload.service';
-import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -32,7 +32,7 @@ export class DialogService {
   }
 
   openUploadConfirmationDialog(file: File) {
-    let preview = undefined;
+    let preview;
     if (this.uploadService.isImageFile(file.name)) {
       preview = new Observable<string | ArrayBuffer>((observer) => {
         const reader = new FileReader();

--- a/src/app/core/services/dialog.service.ts
+++ b/src/app/core/services/dialog.service.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material';
+import { UploadDialogComponent } from '../../shared/upload-dialog/upload-dialog.component';
 import { LabelDefinitionPopupComponent } from '../../shared/label-definition-popup/label-definition-popup.component';
 import { UserConfirmationComponent } from '../guards/user-confirmation/user-confirmation.component';
+import { UploadService } from './upload.service';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DialogService {
-  constructor(private dialog: MatDialog) {}
+  constructor(private dialog: MatDialog, private uploadService: UploadService) {}
 
   openUserConfirmationModal(messages: string[], yesButtonMessage: string, noButtonMessage: string) {
     return this.dialog.open(UserConfirmationComponent, {
@@ -24,6 +27,28 @@ export class DialogService {
       data: {
         header: labelName,
         body: labelDefinition
+      }
+    });
+  }
+
+  openUploadConfirmationDialog(file: File) {
+    const preview = new Observable<string | ArrayBuffer>((observer) => {
+      if (this.uploadService.isImageFile(file.name)) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          observer.next(reader.result);
+        };
+        reader.readAsDataURL(file);
+      } else {
+        observer.next(
+          'https://media.istockphoto.com/photos/european-short-haired-cat-picture-id1072769156?k=20&m=1072769156&s=612x612&w=0&h=k6eFXtE7bpEmR2ns5p3qe_KYh098CVLMz4iKm5OuO6Y='
+        );
+      }
+    });
+    return this.dialog.open(UploadDialogComponent, {
+      data: {
+        name: file.name,
+        preview
       }
     });
   }

--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -4,9 +4,8 @@ import { uuid } from '../../shared/lib/uuid';
 import { GithubService } from './github.service';
 
 const SUPPORTED_VIDEO_FILE_TYPES = ['mp4', 'mov'];
-const SUPPORTED_IMAGE_FILE_TYPES = ['jpeg', 'jpg', 'png'];
+const SUPPORTED_IMAGE_FILE_TYPES = ['jpeg', 'jpg', 'png', 'gif'];
 export const SUPPORTED_FILE_TYPES = [
-  'gif',
   'docx',
   'gz',
   'log',

--- a/src/app/core/services/upload.service.ts
+++ b/src/app/core/services/upload.service.ts
@@ -4,11 +4,9 @@ import { uuid } from '../../shared/lib/uuid';
 import { GithubService } from './github.service';
 
 const SUPPORTED_VIDEO_FILE_TYPES = ['mp4', 'mov'];
+const SUPPORTED_IMAGE_FILE_TYPES = ['jpeg', 'jpg', 'png'];
 export const SUPPORTED_FILE_TYPES = [
   'gif',
-  'jpeg',
-  'jpg',
-  'png',
   'docx',
   'gz',
   'log',
@@ -17,7 +15,8 @@ export const SUPPORTED_FILE_TYPES = [
   'txt',
   'xlsx',
   'zip',
-  ...SUPPORTED_VIDEO_FILE_TYPES
+  ...SUPPORTED_VIDEO_FILE_TYPES,
+  ...SUPPORTED_IMAGE_FILE_TYPES
 ];
 export const FILE_TYPE_SUPPORT_ERROR = "We don't support that file type." + ' Try again with ' + SUPPORTED_FILE_TYPES.join(', ') + '.';
 /**
@@ -67,5 +66,10 @@ export class UploadService {
   isSupportedFileType(fileName): boolean {
     const fileType = this.getFileExtension(fileName);
     return SUPPORTED_FILE_TYPES.includes(fileType.toLowerCase());
+  }
+
+  isImageFile(filename): boolean {
+    const fileType = this.getFileExtension(filename);
+    return SUPPORTED_IMAGE_FILE_TYPES.includes(fileType.toLowerCase());
   }
 }

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -1,9 +1,11 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
+import { MatDialog } from '@angular/material';
 import * as DOMPurify from 'dompurify';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { LoggingService } from '../../core/services/logging.service';
+import { DialogService } from '../../core/services/dialog.service';
 import { FILE_TYPE_SUPPORT_ERROR, getSizeExceedErrorMsg, SUPPORTED_FILE_TYPES, UploadService } from '../../core/services/upload.service';
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
@@ -23,7 +25,13 @@ const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_M
 export class CommentEditorComponent implements OnInit {
   readonly SUPPORTED_FILE_TYPES = SUPPORTED_FILE_TYPES;
 
-  constructor(private uploadService: UploadService, private errorHandlingService: ErrorHandlingService, private logger: LoggingService) {}
+  constructor(
+    private dialogService: DialogService,
+    private uploadService: UploadService,
+    private errorHandlingService: ErrorHandlingService,
+    private logger: LoggingService,
+    public dialog: MatDialog
+  ) {}
 
   @Input() commentField: AbstractControl; // Compulsory Input
   @Input() commentForm: FormGroup; // Compulsory Input
@@ -111,11 +119,21 @@ export class CommentEditorComponent implements OnInit {
     this.commentTextArea.nativeElement.focus();
 
     for (let i = 0; i < files.length; i++) {
-      setTimeout(() => {
-        this.logger.info(`File ${i + 1} of ${files.length}. Begin uploading ${files[i].name}.`);
-        this.readAndUploadFile(files[i]);
-      }, TIME_BETWEEN_UPLOADS_MS * i);
+      this.openUploadConfirmation(files[i]);
+      // setTimeout(() => {
+      //   this.logger.info(`File ${i + 1} of ${files.length}. Begin uploading ${files[i].name}.`);
+      //   this.readAndUploadFile(files[i]);
+      // }, TIME_BETWEEN_UPLOADS_MS * i);
     }
+  }
+
+  openUploadConfirmation(file) {
+    const dialogRef = this.dialogService.openUploadConfirmationDialog(file);
+    dialogRef.afterClosed().subscribe((res) => {
+      if (res) {
+        this.readAndUploadFile(file);
+      }
+    });
   }
 
   onDragExit(event) {
@@ -131,7 +149,7 @@ export class CommentEditorComponent implements OnInit {
 
     const files = fileInput.files;
     if (files.length > 0) {
-      this.readAndUploadFile(files[0]);
+      this.openUploadConfirmation(files[0]);
       fileInput.value = '';
     }
   }
@@ -202,7 +220,7 @@ export class CommentEditorComponent implements OnInit {
       }
     }
     if (blob) {
-      this.readAndUploadFile(blob);
+      this.openUploadConfirmation(blob);
     }
   }
 

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -3,16 +3,15 @@ import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angu
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material';
 import * as DOMPurify from 'dompurify';
+import { DialogService } from '../../core/services/dialog.service';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { LoggingService } from '../../core/services/logging.service';
-import { DialogService } from '../../core/services/dialog.service';
 import { FILE_TYPE_SUPPORT_ERROR, getSizeExceedErrorMsg, SUPPORTED_FILE_TYPES, UploadService } from '../../core/services/upload.service';
 
 const DISPLAYABLE_CONTENT = ['gif', 'jpeg', 'jpg', 'png'];
 const BYTES_PER_MB = 1024 * 1024;
 const SHOWN_MAX_UPLOAD_SIZE_MB = 10;
 const SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB = 5;
-const TIME_BETWEEN_UPLOADS_MS = 250;
 
 const MAX_UPLOAD_SIZE = (SHOWN_MAX_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 11MB to allow 10.x MB
 const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 6MB to allow 5.x MB

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -120,10 +120,6 @@ export class CommentEditorComponent implements OnInit {
 
     for (let i = 0; i < files.length; i++) {
       this.openUploadConfirmation(files[i]);
-      // setTimeout(() => {
-      //   this.logger.info(`File ${i + 1} of ${files.length}. Begin uploading ${files[i].name}.`);
-      //   this.readAndUploadFile(files[i]);
-      // }, TIME_BETWEEN_UPLOADS_MS * i);
     }
   }
 

--- a/src/app/shared/upload-dialog/upload-dialog.component.html
+++ b/src/app/shared/upload-dialog/upload-dialog.component.html
@@ -1,6 +1,9 @@
 <h2 mat-dialog-title>Are you sure you want to upload {{ data.name }}?</h2>
 <div mat-dialog-content>
-  <img [src]="data.preview | async" alt="oh dearie me" />
+  <img *ngIf="data.preview; else elseBlock" [src]="data.preview | async" alt="Unable to show image preview" />
+  <ng-template #elseBlock>
+    <p>No preview available</p>
+  </ng-template>
 </div>
 <div mat-dialog-actions>
   <button mat-button (click)="onCancel()">Cancel</button>

--- a/src/app/shared/upload-dialog/upload-dialog.component.html
+++ b/src/app/shared/upload-dialog/upload-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>Are you sure you want to upload {{ data.name }}?</h2>
+<div mat-dialog-content>
+  <img [src]="data.preview | async" alt="oh dearie me" />
+</div>
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-button (click)="onConfirm()">Confirm</button>
+</div>

--- a/src/app/shared/upload-dialog/upload-dialog.component.ts
+++ b/src/app/shared/upload-dialog/upload-dialog.component.ts
@@ -1,0 +1,23 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-upload-dialog',
+  templateUrl: './upload-dialog.component.html',
+  styleUrls: ['./upload-dialog.component.css']
+})
+export class UploadDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<UploadDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { name: string; preview: Observable<ArrayBuffer | string> }
+  ) {}
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/src/app/shared/upload-dialog/upload-dialog.component.ts
+++ b/src/app/shared/upload-dialog/upload-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { Observable } from 'rxjs';
 
 @Component({


### PR DESCRIPTION
### Summary:
Fixes #[-]

### Changes Made:
* When the user uploads a file in the `comment-editor`, a confirmation dialog will be presented with the name of the file + a preview if the file is of image type.
* Direct calls to `readAndUploadFile` in the `CommentEditorComponent` were replaced with the new `openUploadConfirmation` method
* `openUploadConfirmation` method uses the new `openUploadConfirmationDialog` from the expanded `DialogService`, and listens for the user's input to the dialog. If the user clicks `cancel`, no upload is performed, and vice versa if the user clicks `confirm`.
* The `openUploadConfirmationDialog` mentioned above reads the uploaded file and passes the preview data to the `UploadDialogComponent` if preview-able.
* The `UploadDialogComponent` simply shows the filename, preview (if applicable) and cancel/confirm buttons.
* Minor refactorings were made in `UploadService` to support the `isImageFile` query.

Preview of changes:
<img width="858" alt="image" src="https://user-images.githubusercontent.com/77093722/173222041-e0038d29-fb29-43af-a89a-b4f78f6a6ae2.png">


### Proposed Commit Message:
```
Prompt the user with an upload confirmation dialog when file upload is initiated.

Currently, the user is not provided with any prompt to verify that he is uploading 
the right files. It can be a slight hassle to have to switch to the preview tab to check 
the files. If the user would like to remove files that were unintentionally added, he 
has to manually highlight and remove text from the comment body.

Let's prompt the user with dialog, which shows the filename and image preview (if 
applicable), which allows the user to conveniently confirm that he is uploading the 
right file with a single click, potentially saving precious seconds in a timed 
environment.

Possible future extension: support video preview in the dialog
```
